### PR TITLE
brute fix for floating error causing missing circle in demo

### DIFF
--- a/demo/utils.ts
+++ b/demo/utils.ts
@@ -1,9 +1,11 @@
-import { random, sum } from 'lodash'
+import { random } from 'lodash'
 
 export function randomWithFixedSum(amount: number, sum: number) {
   const numbers = Array(amount).fill(0).map(Math.random)
   const randomSum = numbers.reduce((a, b) => a + b, 0)
-  return numbers.map((n) => (n * sum) / randomSum)
+  const generated = numbers.map((n) => (n * sum) / randomSum)
+  const diff = generated.reduce((a, g) => a + g, 0) - sum
+  return diff ? randomWithFixedSum(amount, sum) : generated
 }
 
 export function randomColor() {
@@ -13,7 +15,7 @@ export function randomColor() {
 export function generateData(counterExtents: [number, number] = [2, 6], sumValue = 1) {
   const [minCounter, maxCounter] = counterExtents
   const n = random(minCounter, maxCounter)
-  let percentages = randomWithFixedSum(n, sumValue)
+  const percentages = randomWithFixedSum(n, sumValue)
   const dataset = percentages.map((p) => p)
   return dataset
 }


### PR DESCRIPTION
Randomly (it looks like ~ 20% of the times) the demo will fail to generate the circle due to the fact that the percentages sum is !== 1.
This is due to JS floating point error. It could be solved using external libraries but simply checking if the sum is correct and generating the numbers again if not seems to work fine.